### PR TITLE
🔨 using more reliable selectors and improving the page loading strategy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 RUN playwright install-deps
 RUN playwright install
+RUN mkdir -p /app/data
 
 COPY ./api /app/api
 COPY ./lib /app/lib

--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@
 Library and API server to retrieve YouTube content using web scraping and the YouTube Data API. 
 
 
+## Caveats
+
+- YouTube webpages do not currently expose following data: shares count, dislikes count, upload_date. 
+This is not available by scraping and has to be retrieved by the YT API.
+
+
 ## Preps.
 
 1. Create virtual env
@@ -49,10 +55,20 @@ Note: Cost of retrieving YT videos is 1 unit per 50 videos capped at 10k units/d
 https://developers.google.com/youtube/v3/determine_quota_cost
 
 
+Required envs:
+
 ```shell
 YT_API_KEY=XXXX...
 ```
 
+The following have [presets](./helpers.py):
+
+```shell
+IO_TIMEOUT=60000
+IO_RATE_LIMIT=1
+IO_BATCH_SIZE=3
+IO_CONCURRENCY_LIMIT=5
+```
 
 ##  API server
 
@@ -105,32 +121,33 @@ YT_API_KEY=XXXX...
     
     ```bash
     curl http://localhost:8000/results/20250209_123456
-    
-    # Response example:
-    # {
-    #   "results": [
-    #     {
-    #       "video_id": "dQw4w9WgXcQ",
-    #       "title": "Rick Astley - Never Gonna Give You Up",
-    #       "views": 1234567,
-    #       "likes": 12345,
-    #       "comments": 1234,
-    #       "upload_date": "Oct 25, 2009",
-    #       "channel_name": "Rick Astley",
-    #       "url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
-    #     },
-    #     {
-    #       "video_id": "jNQXAC9IVRw",
-    #       "title": "Me at the zoo",
-    #       "views": 7654321,
-    #       "likes": 54321,
-    #       "comments": 4321,
-    #       "upload_date": "Apr 23, 2005",
-    #       "channel_name": "jawed",
-    #       "url": "https://www.youtube.com/watch?v=jNQXAC9IVRw"
-    #     }
-    #   ]
-    # }
+    ```
+
+    ```json
+      {
+      "results": [
+        {
+          "video_id": "dQw4w9WgXcQ",
+          "title": "Rick Astley - Never Gonna Give You Up",
+          "views": 1234567,
+          "likes": 12345,
+          "comments": 1234,
+          "upload_date": "Oct 25, 2009",
+          "channel_name": "Rick Astley",
+          "url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+        },
+        {
+          "video_id": "jNQXAC9IVRw",
+          "title": "Me at the zoo",
+          "views": 7654321,
+          "likes": 54321,
+          "comments": 4321,
+          "upload_date": "Apr 23, 2005",
+          "channel_name": "jawed",
+          "url": "https://www.youtube.com/watch?v=jNQXAC9IVRw"
+        }
+      ]
+    }
     ```
 
 

--- a/helpers.py
+++ b/helpers.py
@@ -3,18 +3,17 @@ import pathlib
 
 
 # timeout to scrape/fetch, default 30000
-IO_TIMEOUT = 60000
+IO_TIMEOUT = os.getenv("IO_TIMEOUT", 90000)
 
 # asyncio semaphore limit
-IO_CONCURRENCY_LIMIT = 5
+IO_CONCURRENCY_LIMIT = os.getenv("IO_CONCURRENCY_LIMIT", 5)
 
 # max number of tasks spawned per second
-IO_RATE_LIMIT = 1
+IO_RATE_LIMIT = os.getenv("IO_RATE_LIMIT", 1)
 
 # I/O size incl. queue length before flushing to storage
 # also 50 max video ids currently allowed to be requested at once by the YT API.
-# recommended value 50
-IO_BATCH_SIZE = 3
+IO_BATCH_SIZE = os.getenv("IO_BATCH_SIZE", 50)
 
 
 __all__ = (


### PR DESCRIPTION
Attempts to fix below error which only occurs on staging:

```json
 {
    "results": {
        "errors": [
            {
                "message": "🚫 async error: Error scraping video \"Vmb2os3nqVA\"",
                "detail": "Page.wait_for_selector: Timeout 60000ms exceeded.\nCall log:\n  - waiting for locator(\"#contents\") to be visible\n  -     11 × locator resolved to 5 elements. Proceeding with the first one: <div id=\"contents\" class=\"style-scope ytd-reel-shelf-renderer\">…</div>\n  -     42 × locator resolved to 6 elements. Proceeding with the first one: <div id=\"contents\" class=\"style-scope ytd-reel-shelf-renderer\">…</div>\n",
                "errors": "Traceback (most recent call last):\n  File \"/app/lib/scraper.py\", line 182, in scrape_video_stats\n    await page.wait_for_selector('#contents', timeout=IO_TIMEOUT)\n  File \"/usr/local/lib/python3.11/site-packages/playwright/async_api/_generated.py\", line 8162, in wait_for_selector\n    await self._impl_obj.wait_for_selector(\n  File \"/usr/local/lib/python3.11/site-packages/playwright/_impl/_page.py\", line 424, in wait_for_selector\n    return await self._main_frame.wait_for_selector(**locals_to_params(locals()))\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/usr/local/lib/python3.11/site-packages/playwright/_impl/_frame.py\", line 323, in wait_for_selector\n    await self._channel.send(\"waitForSelector\", locals_to_params(locals()))\n  File \"/usr/local/lib/python3.11/site-packages/playwright/_impl/_connection.py\", line 61, in send\n    return await self._connection.wrap_api_call(\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/usr/local/lib/python3.11/site-packages/playwright/_impl/_connection.py\", line 528, in wrap_api_call\n    raise rewrite_error(error, f\"{parsed_st['apiName']}: {error}\") from None\nplaywright._impl._errors.TimeoutError: Page.wait_for_selector: Timeout 60000ms exceeded.\nCall log:\n  - waiting for locator(\"#contents\") to be visible\n  -     11 × locator resolved to 5 elements. Proceeding with the first one: <div id=\"contents\" class=\"style-scope ytd-reel-shelf-renderer\">…</div>\n  -     42 × locator resolved to 6 elements. Proceeding with the first one: <div id=\"contents\" class=\"style-scope ytd-reel-shelf-renderer\">…</div>\n\n",
                "video_id": "Vmb2os3nqVA"
            }
        ]
    }
}
```

By:

- Using more specific selectors for each element (like h1.ytd-watch-metadata yt-formatted-string for the title)
- Changing the page loading strategy
- Adding explicit waits for key elements

Minor changes:

- Improved doc
- Load vars from env ie. IO_TIMEOUT, IO_CONCURRENCY_LIMIT, IO_RATE_LIMIT, IO_BATCH_SIZE