### PR TITLE
Deploy the ytdt to production

### DIFF
--- a/.github/workflows/.ci.yml
+++ b/.github/workflows/.ci.yml
@@ -35,6 +35,6 @@ jobs:
 
       - name: Build and Push Docker Image
         run: |
-          IMAGE_TAG=registry.ceduth.dev/jfp/yt-retriever:latest
+          IMAGE_TAG=registry.ceduth.dev/jfp/ytdt-api:latest
           docker build -t $IMAGE_TAG .
           docker push $IMAGE_TAG

--- a/README.md
+++ b/README.md
@@ -1,15 +1,20 @@
 # ytdt-api
 
-Library and API server to retrieve YouTube content using web scraping and the YouTube Data API. 
+`ytdt-api` exposes the core functionality of the YouTube Data Tools.
+as a python library, a webservice, and several utility scripts. 
+
+YouTube Data Tools: ML experimentation toolkit on YouTube data. Easily extract YouTube data, gather video statistics, explore API data, and gain novel audience insights.
 
 
 ## Caveats
 
-- YouTube webpages do not currently expose following data: shares count, dislikes count, upload_date.
-This is not available by scraping and has to be retrieved by the YT API.
+- YouTube webpages do not currently expose following data: shares count, dislikes count, upload_date. This is not available by scraping and has to be retrieved by the YT API.
+
+- Scrapping: YouTube employs robust anti-scraping measures, including IP blocking and CAPTCHAs, to prevent automated scraping of its data. 
+Tweak the various IO_* environment variables to throttle the various multi-threading async I/O tasks. Please perform ethical and sustainable web scraping. Don't redistribute scraped data, especially not in bulk form. This protects user privacy.
 
 
-## Preps.
+## Dev setup.
 
 1. Create virtual env
 
@@ -70,7 +75,7 @@ IO_BATCH_SIZE=3
 IO_CONCURRENCY_LIMIT=5
 ```
 
-##  API server
+##  API Server
 
 ### Start the server locally (dev) or hit [YTDT online server](https://ytdt.ceduth.dev/).
 
@@ -237,7 +242,7 @@ available_videos.py data/wc_jfp_youtube_video_d.csv -u data/unavailable_videos.c
 ## Deploy
 
 
-## Deploy locally
+### Deploy locally
 
 
 ```shell
@@ -249,7 +254,7 @@ Open http://localhost:8000
 
 
 
-## Deploy to Kubernetes 
+### Deploy to Kubernetes 
 
 1. Add following secrets to GitHub repository
 
@@ -259,6 +264,6 @@ gh secret set HARBOR_PASSWORD --body "your-password-value"
 gh secret set YT_API_KEY --body "your-youtube-api-key"
 ```
 
-## TODO
+## Known Bugs
 
-* Fix comments count = 0 most of the time
+* Comments count return from scrapping has 0 value most of the time.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# yt-retriever
+# ytdt-api
 
 Library and API server to retrieve YouTube content using web scraping and the YouTube Data API. 
 
@@ -72,11 +72,16 @@ IO_CONCURRENCY_LIMIT=5
 
 ##  API server
 
-### Start the server locally (dev) or hit [YTDT online server](https://yt.ceduth.dev/).
+### Start the server locally (dev) or hit [YTDT online server](https://ytdt.ceduth.dev/).
+
+    ```shell
+    PYTHONPATH=$PYTHONPATH:. uvicorn api.main:app \
+      --host 127.0.0.1 --port 8000 --reload
+    ```
 
     ```shell
     cd backend
-    PYTHONPATH=$PYTHONPATH:/Users/ceduth/Devl/JFP/yt-retriever/backend/api  \
+    PYTHONPATH=$PYTHONPATH:/Users/ceduth/Devl/JFP/ytdt-api/backend/api  \
       uvicorn main:app --reload --app-dir=./api
     ```
 
@@ -87,7 +92,7 @@ IO_CONCURRENCY_LIMIT=5
   Online:
 
   ```
-  curl -X POST https://yt.ceduth.dev/api/external/scrape \
+  curl -X POST https://ytdt.ceduth.dev/api/external/scrape \
   -H "Content-Type: application/json" \
   -d '{ "video_ids": ["Znm_glAFMUQ"] }'
   ```
@@ -115,7 +120,7 @@ IO_CONCURRENCY_LIMIT=5
 2. Fetch videos using the YouTube Data API v3
 
   ```shell
-    curl -X POST https://yt.ceduth.dev/api/external/fetch \
+    curl -X POST https://ytdt.ceduth.dev/api/external/fetch \
     -H "Content-Type: application/json" \
     -d '{ "video_ids": ["Znm_glAFMUQ"] }'
   ```
@@ -197,7 +202,7 @@ Example:
 ```bash
 chmod +x plays_api_x_website.py
 
-PYTHONPATH=$PYTHONPATH:/Users/ceduth/Devl/JFP/yt-retriever/backend/  \
+PYTHONPATH=$PYTHONPATH:.  \
 ./scripts/plays_api_x_website.py data/video-ids-three.csv \
   --include_fields=published_at,upload_date,duration,view_count,scraped_published_at,scraped_upload_date,scraped_upload_date,scraped_duration,scraped_view_count
 ```
@@ -232,16 +237,12 @@ available_videos.py data/wc_jfp_youtube_video_d.csv -u data/unavailable_videos.c
 ## Deploy
 
 
-## Test locally
+## Deploy locally
+
 
 ```shell
-PYTHONPATH=$PYTHONPATH:/Users/ceduth/Devl/Projects/yt-retriever uvicorn api.main:app \
-  --host 127.0.0.1 --port 8000 --reload
-```
-
-```shell
-docker build -t yt-retriever .
-docker run -p 8000:80 yt-retriever
+docker build -t ytdt-api .
+docker run -p 8000:80 ytdt-api
 ```
 
 Open http://localhost:8000 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ IO_CONCURRENCY_LIMIT=5
 
 ##  API server
 
-1. Start the server
+### Start the server locally (dev) or hit [YTDT online server](https://yt.ceduth.dev/).
 
     ```shell
     cd backend
@@ -80,7 +80,19 @@ IO_CONCURRENCY_LIMIT=5
       uvicorn main:app --reload --app-dir=./api
     ```
 
-2. API routes
+### API routes
+
+1. Start a scraping job
+
+  Online:
+
+  ```
+  curl -X POST https://yt.ceduth.dev/api/external/scrape \
+  -H "Content-Type: application/json" \
+  -d '{ "video_ids": ["Znm_glAFMUQ"] }'
+  ```
+
+  Or locally, iff followed above dev setup:
 
     ```shell
     curl -X POST http://localhost:8000/scrape \
@@ -98,6 +110,16 @@ IO_CONCURRENCY_LIMIT=5
     # Response example:
     # {"job_id": "20250209_150714"}
     ```
+  Or 
+
+2. Fetch videos using the YouTube Data API v3
+
+  ```shell
+    curl -X POST https://yt.ceduth.dev/api/external/fetch \
+    -H "Content-Type: application/json" \
+    -d '{ "video_ids": ["Znm_glAFMUQ"] }'
+  ```
+
 
 3. Check job status:
 

--- a/api/main.py
+++ b/api/main.py
@@ -128,8 +128,8 @@ async def get_results(job_id: str):
 @app.get("/")
 async def get_version():
     return {
-        "name": "yt-retriever",
-        "description": "API for scraping YouTube video data",    
+        "name": "ytdt-api",
+        "description": "YouTube Data Tools API",    
         "version": "0.1.0"
     }
 

--- a/api/main.py
+++ b/api/main.py
@@ -8,12 +8,12 @@ from fastapi import FastAPI, BackgroundTasks
 from fastapi.middleware.cors import CORSMiddleware
 
 from helpers import IO_TIMEOUT
-from lib.scraper import YouTubeVideoScraper, scrape_multiple_videos
+from lib.videos import fetch_multiple_videos
+from lib.scraper import scrape_multiple_videos
 from pydantic import BaseModel
 from typing import List, Dict, Optional
 from datetime import datetime
 
-from lib.videos import fetch_multiple_videos
 
 
 app = FastAPI()
@@ -81,7 +81,7 @@ async def run_tool(tool_name, job_id: str, video_ids: List[str]):
 
 
 @app.post("/{tool_name}")
-async def start_scrape(request: ScrapeRequest, background_tasks: BackgroundTasks, tool_name: str):
+async def start_tool(request: ScrapeRequest, background_tasks: BackgroundTasks, tool_name: str):
 
     if tool_name not in yt_data_tools:
         return {"error": f"Invalid request, no such tool: {tool_name}"}

--- a/lib/scraper.py
+++ b/lib/scraper.py
@@ -33,10 +33,10 @@ logging.basicConfig(level=LOG_LEVEL)
 
 class YouTubeVideoScraper:
 
-    def __init__(self, concurrency=IO_CONCURRENCY_LIMIT):
+    def __init__(self, concurrency=None):
         self.browser = None
         self.page = None
-        self.concurrency = concurrency
+        self.concurrency = concurrency or int(IO_CONCURRENCY_LIMIT)
 
     async def __aenter__(self):
         self.playwright = await async_playwright().start()
@@ -376,7 +376,7 @@ class YouTubeVideoScraper:
                 return await aiometer.run_all([
                     functools.partial(_scrape_to_pipeline, pipeline, i, v)
                     for i, v in enumerate(tqdm(video_ids, desc=desc))
-                ], max_per_second=IO_RATE_LIMIT, max_at_once=IO_CONCURRENCY_LIMIT)
+                ], max_per_second=IO_RATE_LIMIT, max_at_once=self.concurrency)
 
         return await run_tasks(video_ids)
 

--- a/lib/videos.py
+++ b/lib/videos.py
@@ -82,7 +82,8 @@ async def fetch_multiple_videos(video_ids, progress_callback=None, **pipeline_kw
             # TODO: only AsyncException are currently properly formatted for savin to csv
             await pipeline.enqueue(e.__dict__, is_error=True), -1
 
-    async def run_tasks(video_ids: [str]):
+
+    async def run_tasks(video_ids: list[str]):
 
         results = defaultdict(list)
 
@@ -114,7 +115,7 @@ async def fetch_multiple_videos(video_ids, progress_callback=None, **pipeline_kw
                          for i, v in enumerate(tqdm(response['items'], desc=batch_desc))]
 
                 for item, err_code in (await aiometer.run_all(
-                  tasks, max_per_second=IO_RATE_LIMIT, max_at_once=IO_CONCURRENCY_LIMIT)
+                  tasks, max_per_second=IO_RATE_LIMIT, max_at_once=int(IO_CONCURRENCY_LIMIT))
                 ):
                     key = 'videos' if err_code > -1 else 'errors'
                     item = asdict(item)


### PR DESCRIPTION
### Deploy to production Kubernetes cluster.

1. Fix error: ```HotFix: Error: '<=' not supported between instances of 'str' and 'int'```
due to aiometer.run_all() enforcing an internal check of arg **max_at_once** arg - to be an int.
Happens only in production where the the IO_CONCURRENCY_LIMIT env is specifically set.

2. Rebrand from `yt-retriever` to `ytdt-api`.
